### PR TITLE
ScoreTypeEnum2StringConverter renamed to ScoreTypeResolveConverter

### DIFF
--- a/src/main/java/ru/dragonestia/jdash/config/WebContext.java
+++ b/src/main/java/ru/dragonestia/jdash/config/WebContext.java
@@ -6,7 +6,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import ru.dragonestia.jdash.JDashApplication;
-import ru.dragonestia.jdash.converter.ScoreTypeEnum2StringConverter;
+import ru.dragonestia.jdash.converter.ScoreTypeResolveConverter;
 import ru.dragonestia.jdash.gd.account.AccountManager;
 import ru.dragonestia.jdash.interceptor.AccountAuthorisationInterceptor;
 import ru.dragonestia.jdash.interceptor.DebugInterceptor;
@@ -29,6 +29,6 @@ public class WebContext implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new ScoreTypeEnum2StringConverter());
+        registry.addConverter(new ScoreTypeResolveConverter());
     }
 }

--- a/src/main/java/ru/dragonestia/jdash/converter/ScoreTypeResolveConverter.java
+++ b/src/main/java/ru/dragonestia/jdash/converter/ScoreTypeResolveConverter.java
@@ -3,7 +3,7 @@ package ru.dragonestia.jdash.converter;
 import org.springframework.core.convert.converter.Converter;
 import ru.dragonestia.jdash.gd.util.score.ScoreType;
 
-public class ScoreTypeEnum2StringConverter implements Converter<String, ScoreType> {
+public class ScoreTypeResolveConverter implements Converter<String, ScoreType> {
 
     @Override
     public ScoreType convert(String source) {


### PR DESCRIPTION
The name ScoreTypeEnum2StringConverter means that the class converts the ScoreTypeEnum to a string, but in fact the class does the opposite.